### PR TITLE
Update lua script to convert poll_interval to MS

### DIFF
--- a/orchagent/rif_rates.lua
+++ b/orchagent/rif_rates.lua
@@ -45,10 +45,10 @@ for i = 1, n do
         local out_pkts_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last')
         
         -- Calculate new rates values
-        local rx_bps_new = (in_octets - in_octets_last)/delta
-        local tx_bps_new = (out_octets - out_octets_last)/delta
-        local rx_pps_new = (in_pkts - in_pkts_last)/delta
-        local tx_pps_new = (out_pkts - out_pkts_last)/delta
+        local rx_bps_new = (in_octets - in_octets_last) / delta * 1000
+        local tx_bps_new = (out_octets - out_octets_last) / delta * 1000
+        local rx_pps_new = (in_pkts - in_pkts_last) / delta * 1000
+        local tx_pps_new = (out_pkts - out_pkts_last) / delta * 1000
 
         if initialized == "DONE" then
             -- Get old rates values


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Update the rif_rates/lua script to multiply by 1000 instead of FlexCounter class.
related also to - sonic-sairedis/pull/878
**Why I did it**
times were not calculated properly.
**How I verified it**
check that the output of cli and redis is close enough:

```
admin@sonic:~$ show interfaces counters rif -p 5
The rates are calculated within 5 seconds period
    IFACE    RX_OK     RX_BPS    RX_PPS    RX_ERR    TX_OK    TX_BPS    TX_PPS    TX_ERR
---------  -------  ---------  --------  --------  -------  --------  --------  --------
Ethernet0        5  83.90 B/s    1.00/s         1        0  0.00 B/s    0.00/s         0
```

```
127.0.0.1:6379[2]> hgetall RATES:oid:0x6000000000d9d
 1) "SAI_ROUTER_INTERFACE_STAT_IN_OCTETS_last"
 2) "3948"
 3) "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last"
 4) "47"
 5) "SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last"
 6) "0"
 7) "SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last"
 8) "0"
 9) "RX_BPS"
10) "77.634107320096575"
11) "RX_PPS"
12) "0.92421556333448329"
13) "TX_BPS"
14) "0"
15) "TX_PPS"
16) "0"

```

before the change:
```
admin@sonic:~$ show interfaces  counters rif -p 5
The rates are calculated within 5 seconds period
     IFACE    RX_OK       RX_BPS     RX_PPS    RX_ERR    TX_OK    TX_BPS    TX_PPS    TX_ERR
----------  -------  -----------  ---------  --------  -------  --------  --------  --------
Ethernet0        0     0.00 B/s     0.00/s         0        0  0.00 B/s    0.00/s         0
Ethernet28   29,894  501.05 KB/s  5964.85/s         1        0  0.00 B/s    0.00/s         0
```

```
127.0.0.1:6379[2]> hgetall "RATES:oid:0x6000000000517"
1) "SAI_ROUTER_INTERFACE_STAT_IN_OCTETS_last"
2) "17856552"
3) "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last"
4) "212578"
5) "SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last"
6) "0"
7) "SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last"
8) "0"
9) "RX_BPS"
10) "67.774654124880783"
11) "RX_PPS"
12) "0.80684145386762807"
13) "TX_BPS"
14) "0"
15) "TX_PPS"
16) "0"

```


**Details if related**
