### PR TITLE
[CoPP] Add redesign change - always_enabled field

### DIFF
--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -98,11 +98,17 @@ void CoppMgr::setFeatureTrapIdsStatus(string feature, bool enable)
 
     if (!enable)
     {
-        m_coppDisabledTraps.insert(feature);
+        if (m_coppAlwaysEnabledTraps.find(feature) == m_coppAlwaysEnabledTraps.end())
+        {
+            m_coppDisabledTraps.insert(feature);
+        }
     }
     else
     {
-        m_coppDisabledTraps.erase(feature);
+        if (m_coppDisabledTraps.find(feature) != m_coppDisabledTraps.end())
+        {
+            m_coppDisabledTraps.erase(feature);
+        }
     }
 
     /* Trap group moved to pending state when feature is disabled. Remove trap group
@@ -159,6 +165,7 @@ bool CoppMgr::isTrapIdDisabled(string trap_id)
     }
     return false;
 }
+
 void CoppMgr::mergeConfig(CoppCfg &init_cfg, CoppCfg &m_cfg, std::vector<std::string> &cfg_keys, Table &cfgTable)
 {
     /* Read the init configuration first. If the same key is present in
@@ -265,12 +272,37 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         }
     }
 
+    /* If there is a trap that has always_enabled = true, remove it from the disabledTraps list */
+    for (auto trap: m_coppTrapInitCfg)
+    {
+        auto trap_name = trap.first;
+        auto trap_info = trap.second;
+        bool always_enabled = false;
+
+        if (std::find(trap_info.begin(), trap_info.end(), FieldValueTuple("always_enabled", "true")) != trap_info.end())
+        {
+            always_enabled = true;
+            m_coppAlwaysEnabledTraps.insert(trap_name);
+
+            if (std::find(m_coppDisabledTraps.begin(), m_coppDisabledTraps.end(), trap_name) != m_coppDisabledTraps.end())
+            {
+                m_coppDisabledTraps.erase(trap_name);
+            }
+        }
+        /* if trap has no feature entry and doesn't have the always_enabled:true field, add to disabledTraps list */
+        if (!(std::count(feature_keys.begin(), feature_keys.end(), trap_name)) && !always_enabled)
+        {
+            m_coppDisabledTraps.insert(trap_name);
+        }
+    }
+
     mergeConfig(m_coppTrapInitCfg, trap_cfg, trap_cfg_keys, m_cfgCoppTrapTable);
 
     for (auto i : trap_cfg)
     {
         string trap_group;
         string trap_ids;
+        string is_always_enabled = "false";
         std::vector<FieldValueTuple> trap_fvs = i.second;
 
         for (auto j: trap_fvs)
@@ -283,13 +315,22 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
             {
                 trap_group = fvValue(j);
             }
+            else if (fvField(j) == COPP_ALWAYS_ENABLED_FIELD)
+            {
+                is_always_enabled = fvValue(j);
+            }
         }
+
         if (!trap_group.empty() && !trap_ids.empty())
         {
-            addTrapIdsToTrapGroup(trap_group, trap_ids);
-            m_coppTrapConfMap[i.first].trap_group = trap_group;
-            m_coppTrapConfMap[i.first].trap_ids = trap_ids;
-            setCoppTrapStateOk(i.first);
+            if (std::find(m_coppDisabledTraps.begin(), m_coppDisabledTraps.end(), i.first) == m_coppDisabledTraps.end())
+            {
+                addTrapIdsToTrapGroup(trap_group, trap_ids);
+                m_coppTrapConfMap[i.first].trap_group = trap_group;
+                m_coppTrapConfMap[i.first].trap_ids = trap_ids;
+                m_coppTrapConfMap[i.first].is_always_enabled = is_always_enabled;
+                setCoppTrapStateOk(i.first);
+            }
         }
     }
 
@@ -316,15 +357,18 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
             trap_group_fvs.push_back(fv);
         }
 
-        if (!trap_group_fvs.empty())
+        if (std::find(m_coppDisabledTraps.begin(), m_coppDisabledTraps.end(), i.first) == m_coppDisabledTraps.end())
         {
-            m_appCoppTable.set(i.first, trap_group_fvs);
-        }
-        setCoppGroupStateOk(i.first);
-        auto g_cfg = std::find(group_cfg_keys.begin(), group_cfg_keys.end(), i.first);
-        if (g_cfg != group_cfg_keys.end())
-        {
-            g_copp_init_set.insert(i.first);
+            if (!trap_group_fvs.empty())
+            {
+                m_appCoppTable.set(i.first, trap_group_fvs);
+            }
+            setCoppGroupStateOk(i.first);
+            auto g_cfg = std::find(group_cfg_keys.begin(), group_cfg_keys.end(), i.first);
+            if (g_cfg != group_cfg_keys.end())
+            {
+                g_copp_init_set.insert(i.first);
+            }
         }
     }
 }
@@ -449,12 +493,21 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
         vector<FieldValueTuple> fvs;
         string trap_ids = "";
         string trap_group = "";
+        string is_always_enabled = "";
         bool   conf_present = false;
 
         if (m_coppTrapConfMap.find(key) != m_coppTrapConfMap.end())
         {
             trap_ids = m_coppTrapConfMap[key].trap_ids;
             trap_group = m_coppTrapConfMap[key].trap_group;
+            if (m_coppTrapConfMap[key].is_always_enabled.empty())
+            {
+                is_always_enabled = "false";
+            }
+            else
+            {
+                is_always_enabled = m_coppTrapConfMap[key].is_always_enabled;
+            }
             conf_present = true;
         }
 
@@ -471,6 +524,10 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
                 else if (fvField(i) == COPP_TRAP_ID_LIST_FIELD)
                 {
                     trap_ids = fvValue(i);
+                }
+                else if (fvField(i) == COPP_ALWAYS_ENABLED_FIELD)
+                {
+                    is_always_enabled = fvValue(i);
                 }
                 else if (fvField(i) == "NULL")
                 {
@@ -494,8 +551,54 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
                 (trap_ids == m_coppTrapConfMap[key].trap_ids) &&
                 (is_always_enabled == m_coppTrapConfMap[key].is_always_enabled))
             {
-                it = consumer.m_toSync.erase(it);
-                continue;
+                std::vector<std::string> feature_keys;
+                m_cfgFeatureTable.getKeys(feature_keys);
+                std::vector<FieldValueTuple> feature_fvs;
+                /* duplicate check for the always_enabled field */
+                if (!m_coppTrapConfMap[key].is_always_enabled.empty() && (is_always_enabled == m_coppTrapConfMap[key].is_always_enabled))
+                {
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+                else if (is_always_enabled == "true")
+                {
+                    /* if the value was changed from false to true,
+                    if the trap is not installed, install it.
+                    otherwise, do nothing. */
+
+                    m_coppAlwaysEnabledTraps.insert(key);
+
+                    if (m_coppTrapConfMap.find(key) == m_coppTrapConfMap.end())
+                    {
+                        string trap_group_trap_ids;
+                        addTrap(fvs, trap_ids, trap_group, is_always_enabled, trap_group_trap_ids);
+                    }
+                }
+                else
+                {
+                    /* if the value was changed from true to false,
+                    check if there is a feature enabled.
+                    if no, remove the trap. is yes, do nothing. */
+
+                    m_coppAlwaysEnabledTraps.erase(key);
+
+                    if (std::find(feature_keys.begin(), feature_keys.end(), key) != feature_keys.end())
+                    {
+                        m_cfgFeatureTable.get(key, feature_fvs);
+                        for (auto i: feature_fvs)
+                        {
+                            if (fvField(i) == "state" && fvValue(i) == "enabled")
+                            {
+                                it = consumer.m_toSync.erase(it);
+                                continue;
+                            }
+                        }
+                    }
+                    removeTrap(key, trap_ids, fvs);
+                    m_coppTrapConfMap.erase(key);
+                    m_coppDisabledTraps.insert(key);
+                }
+
             }
 
             /* Incomplete configuration. Do not process until both trap group
@@ -587,6 +690,7 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
             }
             m_coppTrapConfMap[key].trap_group = trap_group;
             m_coppTrapConfMap[key].trap_ids = trap_ids;
+            m_coppTrapConfMap[key].is_always_enabled = is_always_enabled;
             setCoppTrapStateOk(key);
         }
         else if (op == DEL_COMMAND)
@@ -632,6 +736,10 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
                     {
                         trap_ids = fvValue(i);
                     }
+                    else if (fvField(i) == COPP_ALWAYS_ENABLED_FIELD)
+                    {
+                        is_always_enabled = fvValue(i);
+                    }
                 }
                 vector<FieldValueTuple> g_fvs;
                 string trap_group_trap_ids;
@@ -646,6 +754,7 @@ void CoppMgr::doCoppTrapTask(Consumer &consumer)
                 }
                 m_coppTrapConfMap[key].trap_group = trap_group;
                 m_coppTrapConfMap[key].trap_ids = trap_ids;
+                m_coppTrapConfMap[key].is_always_enabled = is_always_enabled;
                 setCoppTrapStateOk(key);
             }
         }

--- a/cfgmgr/coppmgr.h
+++ b/cfgmgr/coppmgr.h
@@ -73,7 +73,11 @@ private:
     std::set<std::string>  m_coppDisabledTraps;
     CoppCfg                m_coppGroupInitCfg;
     CoppCfg                m_coppTrapInitCfg;
+<<<<<<< HEAD
     CoppCfg                m_featuresCfgTable;
+=======
+    CoppCfg                m_featuresTableCache;
+>>>>>>> 37df59f... Fix CR comments
 
 
     void doTask(Consumer &consumer);

--- a/cfgmgr/coppmgr.h
+++ b/cfgmgr/coppmgr.h
@@ -14,6 +14,7 @@ namespace swss {
 /* COPP Trap Table Fields */
 #define COPP_TRAP_ID_LIST_FIELD                "trap_ids"
 #define COPP_TRAP_GROUP_FIELD                  "trap_group"
+#define COPP_ALWAYS_ENABLED_FIELD              "always_enabled"
 
 /* COPP Group Table Fields */
 #define COPP_GROUP_QUEUE_FIELD                 "queue"
@@ -42,6 +43,7 @@ struct CoppTrapConf
 {
     std::string         trap_ids;
     std::string         trap_group;
+    std::string         is_always_enabled;
 };
 
 /* TrapName to TrapConf map  */
@@ -71,13 +73,10 @@ private:
     CoppTrapIdTrapGroupMap m_coppTrapIdTrapGroupMap;
     CoppGroupFvs           m_coppGroupFvs;
     std::set<std::string>  m_coppDisabledTraps;
+    std::set<std::string>  m_coppAlwaysEnabledTraps;
     CoppCfg                m_coppGroupInitCfg;
     CoppCfg                m_coppTrapInitCfg;
-<<<<<<< HEAD
     CoppCfg                m_featuresCfgTable;
-=======
-    CoppCfg                m_featuresTableCache;
->>>>>>> 37df59f... Fix CR comments
 
 
     void doTask(Consumer &consumer);
@@ -105,7 +104,6 @@ private:
 
     void removeTrap(std::string key);
     void addTrap(std::string trap_ids, std::string trap_group);
-
 };
 
 }

--- a/cfgmgr/coppmgr.h
+++ b/cfgmgr/coppmgr.h
@@ -73,7 +73,8 @@ private:
     std::set<std::string>  m_coppDisabledTraps;
     CoppCfg                m_coppGroupInitCfg;
     CoppCfg                m_coppTrapInitCfg;
-    
+    CoppCfg                m_featuresCfgTable;
+
 
     void doTask(Consumer &consumer);
     void doCoppGroupTask(Consumer &consumer);
@@ -97,6 +98,9 @@ private:
     void parseInitFile(void);
     bool isTrapGroupInstalled(std::string key);
     void mergeConfig(CoppCfg &init_cfg, CoppCfg &m_cfg, std::vector<std::string> &cfg_keys, Table &cfgTable);
+
+    void removeTrap(std::string key);
+    void addTrap(std::string trap_ids, std::string trap_group);
 
 };
 

--- a/tests/test_copp.py
+++ b/tests/test_copp.py
@@ -148,17 +148,18 @@ copp_group_queue5_group1 = {
 	"trap_action": "trap",
 	"trap_priority": "5"
 }
+
 copp_trap = {
-        "bgp,bgpv6": copp_group_queue4_group1,
-        "lacp": copp_group_queue4_group1,
-        "arp_req,arp_resp,neigh_discovery":copp_group_queue4_group2,
-        "lldp":copp_group_queue4_group3,
-        "dhcp,dhcpv6":copp_group_queue4_group3,
-        "udld":copp_group_queue4_group3,
-        "ip2me":copp_group_queue1_group1,
-        "src_nat_miss,dest_nat_miss": copp_group_queue1_group2,
-        "sample_packet": copp_group_queue2_group1,
-        "ttl_error": copp_group_default
+        "bgp": ["bgp;bgpv6", copp_group_queue4_group1],
+        "lacp": ["lacp", copp_group_queue4_group1, "always_enabled"],
+        "arp": ["arp_req;arp_resp;neigh_discovery", copp_group_queue4_group2, "always_enabled"],
+        "lldp": ["lldp", copp_group_queue4_group3],
+        "dhcp": ["dhcp;dhcpv6", copp_group_queue4_group3],
+        "udld": ["udld", copp_group_queue4_group3, "always_enabled"],
+        "ip2me": ["ip2me", copp_group_queue1_group1, "always_enabled"],
+        "nat": ["src_nat_miss;dest_nat_miss", copp_group_queue1_group2],
+        "sflow": ["sample_packet", copp_group_queue2_group1],
+        "ttl": ["ttl_error", copp_group_default]
 }
 
 disabled_traps = ["sample_packet"]
@@ -198,16 +199,16 @@ class TestCopp(object):
         self.trap_ctbl = swsscommon.Table(self.cdb, "COPP_TRAP")
         self.trap_group_ctbl = swsscommon.Table(self.cdb, "COPP_GROUP")
         self.feature_tbl = swsscommon.Table(self.cdb, "FEATURE")
-        fvs = swsscommon.FieldValuePairs([("state", "disbled")])
+        fvs = swsscommon.FieldValuePairs([("state", "disabled")])
         self.feature_tbl.set("sflow", fvs)
         time.sleep(2)
 
-   
+
     def validate_policer(self, policer_oid, field, value):
         (status, fvs) = self.policer_atbl.get(policer_oid)
         assert status == True
         attr = field_to_sai_attr[field]
-        
+
         attr_value = value
         if field == "mode":
             attr_value = policer_mode_map[value]
@@ -219,7 +220,7 @@ class TestCopp(object):
         for fv in fvs:
             if (fv[0] == attr):
                 assert attr_value == fv[1]
-                
+
     def validate_trap_group(self, trap_oid, trap_group):
         (status, trap_fvs) = self.trap_atbl.get(trap_oid)
         assert status == True
@@ -245,11 +246,11 @@ class TestCopp(object):
                     policer_oid = fv[1]
                 elif fv[0] == "SAI_HOSTIF_TRAP_GROUP_ATTR_QUEUE":
                     queue = fv[1]
-                
+
         for keys in trap_group:
             obj_type = field_to_sai_obj_type[keys]
             if obj_type == "SAI_OBJECT_TYPE_POLICER":
-                assert policer_oid != "" 
+                assert policer_oid != ""
                 assert policer_oid != "oid:0x0"
                 self.validate_policer(policer_oid, keys, trap_group[keys])
 
@@ -304,8 +305,12 @@ class TestCopp(object):
         self.setup_copp(dvs)
         trap_keys = self.trap_atbl.getKeys()
         for traps in copp_trap:
-            trap_ids = traps.split(",")
-            trap_group = copp_trap[traps]
+            trap_info = copp_trap[traps]
+            trap_ids = trap_info[0].split(";")
+            trap_group = trap_info[1]
+            always_enabled = False
+            if len(trap_info) > 2:
+                always_enabled = True
             for trap_id in trap_ids:
                 trap_type = traps_to_trap_type[trap_id]
                 trap_found = False
@@ -323,7 +328,6 @@ class TestCopp(object):
                 if trap_id not in disabled_traps:
                     assert trap_found == True
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_restricted_trap_sflow(self, dvs, testlog):
         self.setup_copp(dvs)
         fvs = swsscommon.FieldValuePairs([("state", "enabled")])
@@ -333,11 +337,15 @@ class TestCopp(object):
 
         trap_keys = self.trap_atbl.getKeys()
         for traps in copp_trap:
-            trap_ids = traps.split(",")
+            trap_info = copp_trap[traps]
+            trap_ids = trap_info[0].split(";")
+            trap_group = trap_info[1]
+            always_enabled = False
+            if len(trap_info) > 2:
+                always_enabled = True
             if "sample_packet" not in trap_ids:
                 continue
-            trap_group = copp_trap[traps]
-            trap_found = False 
+            trap_found = False
             trap_type = traps_to_trap_type["sample_packet"]
             for key in trap_keys:
                 (status, fvs) = self.trap_atbl.get(key)
@@ -363,10 +371,14 @@ class TestCopp(object):
 
         trap_keys = self.trap_atbl.getKeys()
         for traps in copp_trap:
-            if copp_trap[traps] != copp_group_queue4_group2:
+            trap_info = copp_trap[traps]
+            trap_ids = trap_info[0].split(";")
+            trap_group = trap_info[1]
+            always_enabled = False
+            if len(trap_info) > 2:
+                always_enabled = True
+            if trap_group != copp_group_queue4_group2:
                 continue
-            trap_ids = traps.split(",")
-            trap_group = copp_trap[traps]
             for trap_id in trap_ids:
                 trap_type = traps_to_trap_type[trap_id]
                 trap_found = False
@@ -391,12 +403,19 @@ class TestCopp(object):
         traps = "bgp,bgpv6"
         fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group1")])
         self.trap_ctbl.set("bgp", fvs)
-        copp_trap[traps] = copp_group_queue1_group1
+
+        for c_trap in copp_trap:
+            trap_info = copp_trap[c_trap]
+            ids = trap_info[0].replace(';', ',')
+            if traps == ids:
+                break
+
+        trap_info[1] = copp_group_queue1_group1
         time.sleep(2)
 
         trap_keys = self.trap_atbl.getKeys()
         trap_ids = traps.split(",")
-        trap_group = copp_trap[traps]
+        trap_group = trap_info[1]
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
             trap_found = False
@@ -425,8 +444,14 @@ class TestCopp(object):
 
         old_traps = "bgp,bgpv6"
         trap_keys = self.trap_atbl.getKeys()
+        for c_trap in copp_trap:
+            trap_info = copp_trap[c_trap]
+            ids = trap_info[0].replace(';', ',')
+            if old_traps == ids:
+                break
+
         trap_ids = old_traps.split(",")
-        trap_group = copp_trap[old_traps]
+        trap_group = trap_info[1]
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
             trap_found = False
@@ -453,7 +478,7 @@ class TestCopp(object):
 
         trap_keys = self.trap_atbl.getKeys()
         trap_ids = traps.split(",")
-        trap_group = copp_trap[traps]
+        trap_group = trap_info[1]
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
             trap_found = False
@@ -481,10 +506,11 @@ class TestCopp(object):
 
         trap_keys = self.trap_atbl.getKeys()
         for traps in copp_trap:
-            if copp_trap[traps] != copp_group_queue4_group1:
+            trap_info = copp_trap[traps]
+            if trap_info[1] != copp_group_queue4_group1:
                 continue
-            trap_ids = traps.split(",")
-            trap_group = copp_trap[traps]
+            trap_ids = trap_info[0].split(";")
+            trap_group = trap_info[1]
             for trap_id in trap_ids:
                 trap_type = traps_to_trap_type[trap_id]
                 trap_found = False
@@ -502,19 +528,21 @@ class TestCopp(object):
                 if trap_id not in disabled_traps:
                     assert trap_found == True
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
+
     def test_new_trap_add(self, dvs, testlog):
         self.setup_copp(dvs)
         global copp_trap
-        traps = "eapol"
-        fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", "eapol")])
+        traps = "eapol,isis,bfd_micro,bfdv6_micro,ldp"
+        fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", traps),("always_enabled", "true")])
         self.trap_ctbl.set(traps, fvs)
-        copp_trap[traps] = copp_group_queue1_group2
+
+
+        copp_trap["eapol"] = [traps, copp_group_queue1_group2, "always_enabled"]
         time.sleep(2)
 
         trap_keys = self.trap_atbl.getKeys()
         trap_ids = traps.split(",")
-        trap_group = copp_trap[traps]
+        trap_group = copp_group_queue1_group2
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
             trap_found = False
@@ -539,13 +567,19 @@ class TestCopp(object):
         traps = "eapol"
         fvs = swsscommon.FieldValuePairs([("trap_group", "queue1_group2"),("trap_ids", "eapol")])
         self.trap_ctbl.set(traps, fvs)
-        copp_trap[traps] = copp_group_queue1_group2
+        for c_trap in copp_trap:
+            trap_info = copp_trap[c_trap]
+            ids = trap_info[0].replace(';', ',')
+            if traps == ids:
+                break
+
+        trap_info[1] = copp_group_queue1_group2
         time.sleep(2)
 
         self.trap_ctbl._del(traps)
         time.sleep(2)
         trap_ids = traps.split(",")
-        trap_group = copp_trap[traps]
+        trap_group = trap_info[1]
         trap_keys = self.trap_atbl.getKeys()
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
@@ -576,12 +610,17 @@ class TestCopp(object):
         traps = "igmp_v1_report"
         t_fvs = swsscommon.FieldValuePairs([("trap_group", "queue5_group1"),("trap_ids", "igmp_v1_report")])
         self.trap_ctbl.set(traps, t_fvs)
-        copp_trap[traps] = copp_group_queue5_group1
+        for c_trap in copp_trap:
+            trap_info = copp_trap[c_trap]
+            ids = trap_info[0].replace(';', ',')
+            if traps == ids:
+                break
+        trap_info[1] = copp_group_queue5_group1
         time.sleep(2)
 
         trap_keys = self.trap_atbl.getKeys()
         trap_ids = traps.split(",")
-        trap_group = copp_trap[traps]
+        trap_group = trap_info[1]
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
             trap_found = False
@@ -611,14 +650,19 @@ class TestCopp(object):
         traps = "igmp_v1_report"
         t_fvs = swsscommon.FieldValuePairs([("trap_group", "queue5_group1"),("trap_ids", "igmp_v1_report")])
         self.trap_ctbl.set(traps, t_fvs)
-        copp_trap[traps] = copp_group_queue5_group1
+        for c_trap in copp_trap:
+            trap_info = copp_trap[c_trap]
+            ids = trap_info[0].replace(';', ',')
+            if traps == ids:
+                break
+        trap_info[1] = copp_group_queue5_group1
 
         self.trap_group_ctbl._del("queue5_group1")
         time.sleep(2)
 
         trap_keys = self.trap_atbl.getKeys()
         trap_ids = traps.split(",")
-        trap_group = copp_trap[traps]
+        trap_group = trap_info[1]
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
             trap_found = False
@@ -651,10 +695,11 @@ class TestCopp(object):
 
         trap_keys = self.trap_atbl.getKeys()
         for traps in copp_trap:
-            if copp_trap[traps] != copp_group_queue1_group1:
+            trap_info = copp_trap[traps]
+            if trap_info[1] != copp_group_queue1_group1:
                 continue
-            trap_ids = traps.split(",")
-            trap_group = copp_trap[traps]
+            trap_ids = trap_info[0].split(";")
+            trap_group = trap_info[1]
             for trap_id in trap_ids:
                 trap_type = traps_to_trap_type[trap_id]
                 trap_found = False
@@ -684,7 +729,7 @@ class TestCopp(object):
         self.trap_ctbl._del("ip2me")
         time.sleep(2)
         trap_ids = traps.split(",")
-        trap_group = copp_trap["ip2me"]
+        trap_group = copp_trap["ip2me"][1]
         trap_keys = self.trap_atbl.getKeys()
         for trap_id in trap_ids:
             trap_type = traps_to_trap_type[trap_id]
@@ -715,7 +760,7 @@ class TestCopp(object):
         time.sleep(2)
 
         trap_id = "ip2me"
-        trap_group = copp_trap["ip2me"]
+        trap_group = copp_trap["ip2me"][1]
         trap_keys = self.trap_atbl.getKeys()
         trap_type = traps_to_trap_type[trap_id]
         trap_found = False
@@ -750,3 +795,58 @@ class TestCopp(object):
                 self.validate_trap_group(key,trap_group)
                 break
         assert trap_found == True
+
+
+    def test_disabled_feature_always_enabled_trap(self, dvs, testlog):
+        self.setup_copp(dvs)
+        fvs = swsscommon.FieldValuePairs([("trap_ids", "bgp,bgpv6"), ("trap_group", "queue4_group1"), ("always_enabled", "true")])
+        self.trap_ctbl.set("bgp", fvs)
+        fvs = swsscommon.FieldValuePairs([("state", "disabled")])
+        self.feature_tbl.set("bgp", fvs)
+
+        time.sleep(2)
+        global copp_trap
+
+        trap_keys = self.trap_atbl.getKeys()
+        for traps in copp_trap:
+            trap_info = copp_trap[traps]
+            trap_ids = trap_info[0].split(";")
+            trap_group = trap_info[1]
+
+            if "bgp" not in trap_ids:
+                continue
+
+            trap_found = False
+            trap_type = traps_to_trap_type["bgp"]
+            for key in trap_keys:
+                (status, fvs) = self.trap_atbl.get(key)
+                assert status == True
+                for fv in fvs:
+                    if fv[0] == "SAI_HOSTIF_TRAP_ATTR_TRAP_TYPE":
+                        if fv[1] == trap_type:
+                            trap_found = True
+                if trap_found:
+                    self.validate_trap_group(key,trap_group)
+                    break
+            assert trap_found == True
+
+        # change always_enabled to be false and check the trap is not installed:
+        fvs = swsscommon.FieldValuePairs([("trap_ids", "bgp,bgpv6"), ("trap_group", "queue4_group1"), ("always_enabled", "false")])
+        self.trap_ctbl.set("bgp", fvs)
+        time.sleep(2)
+
+        table_found = True
+        for key in trap_keys:
+            (status, fvs) = self.trap_atbl.get(key)
+            if status == False:
+                table_found = False
+
+        # teardown
+        fvs = swsscommon.FieldValuePairs([("trap_ids", "bgp,bgpv6"), ("trap_group", "queue4_group1")])
+        self.trap_ctbl.set("bgp", fvs)
+        fvs = swsscommon.FieldValuePairs([("state", "enabled")])
+        self.feature_tbl.set("bgp", fvs)
+
+        assert table_found == False
+
+


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the new design for copp manager - always_enabled field in copp_cfg.json file. 

**Why I did it**
A change was done for traps needs to be installed but doesn't have feature (arp, udld, lacp, ip2me),
in the new implementation, coppmgr will not automatically install traps which has no entry in features table, but will check first if the trap has "always_enabled":"true" field.

**How I verified it**
run tests for making sure traps are installed and not when expecting them to. 
related also to https://github.com/noaOrMlnx/sonic-buildimage/pull/19
**Details if related**
related to sonic-buildimage change - TBD