### PR TITLE
HOST_TX_READY_NOTIFY attr changed to set after query capabilities

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -505,10 +505,6 @@ int main(int argc, char **argv)
     attr.value.ptr = (void *)on_switch_shutdown_request;
     attrs.push_back(attr);
 
-    attr.id = SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY;
-    attr.value.ptr = (void *)on_port_host_tx_ready;
-    attrs.push_back(attr);
-
     if (gMySwitchType != "fabric" && gMacAddress)
     {
         attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6,6 +6,7 @@
 #include "vxlanorch.h"
 #include "directory.h"
 #include "subintf.h"
+#include "notifications.h"
 
 #include <inttypes.h>
 #include <cassert>
@@ -581,6 +582,17 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     {
         SWSS_LOG_DEBUG("m_cmisModuleAsicSyncSupported is true");
         m_cmisModuleAsicSyncSupported = true;
+
+        // set HOST_TX_READY callback function attribute to SAI, only if the feature is enabled
+        sai_attribute_t attr;
+        attr.id = SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY;
+        attr.value.ptr = (void *)on_port_host_tx_ready;
+
+        if (sai_switch_api->set_switch_attribute(gSwitchId, &attr) != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_THROW("PortsOrch failed to set SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY attribute");
+        }
+
         Orch::addExecutor(new Consumer(new SubscriberStateTable(stateDb, STATE_TRANSCEIVER_INFO_TABLE_NAME, TableConsumable::DEFAULT_POP_BATCH_SIZE, 0), this, STATE_TRANSCEIVER_INFO_TABLE_NAME));
     }
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Changed SAI_SWITCH_ATTR_PORT_HOST_TX_READY_NOTIFY callback attribute to be set only after query capabilities approved that CMIS mgmt. feature is enabled. 

**Why I did it**
Before that change, in orchagent/main.cpp, that attribute was set without checking if SAI version is not supporting this feature. 
This could cause an issue to unsupported SAI versions with supported SONiC versions. 

**How I verified it**
Made sure all functionality is the same as before, and this attribute set will not break not-supporting SAI versions.

**Details if related**
